### PR TITLE
If comp nt found chk for all chainId and default

### DIFF
--- a/src/components/service/ServiceMappings.js
+++ b/src/components/service/ServiceMappings.js
@@ -41,6 +41,7 @@ import Places365SceneRecognition from "./Places365SceneRecognition";
 import SuperResolution from "./SuperResolution";
 
 import DefaultService from './DefaultService.js';
+import {NETWORKS} from '../../networks';
 
 const defaultChainId = -1;
 
@@ -96,7 +97,14 @@ export default class SampleServices {
     getComponent(orgId, serviceId, chainId) {
         let component = this.serviceOrgIDToComponent[this.generateUniqueID(orgId, serviceId, chainId)];
         if (typeof component === 'undefined') {
-            component = this.serviceOrgIDToComponent[this.generateUniqueID(orgId, serviceId, defaultChainId)];
+            let chainIds =  [...Object.keys(NETWORKS),defaultChainId];
+            for (let i = 0; i < chainIds.length; i++) {
+                const chainId = chainIds[i];
+                component = this.serviceOrgIDToComponent[this.generateUniqueID(orgId, serviceId, chainId)];
+                if (typeof component !== 'undefined'){
+                    break;
+                }
+            }          
             if (typeof component === 'undefined') {
                 component = DefaultService;
             }


### PR DESCRIPTION
If a component is not found for the given chainID,
* All the chainIds(including default) will be checked for the given orgId, serviceId,
* If still no component is found, the default component is returned.